### PR TITLE
[bug]: fix encoding issue from automatic svn import

### DIFF
--- a/package/kernel/mac80211/patches/351-0017-brcmfmac-drop-unused-pm_block-vif-attribute.patch
+++ b/package/kernel/mac80211/patches/351-0017-brcmfmac-drop-unused-pm_block-vif-attribute.patch
@@ -9,7 +9,7 @@ This attribute was added 3 years ago by
 commit 3eacf866559c ("brcmfmac: introduce brcmf_cfg80211_vif structure")
 but it remains unused since then. It seems we can safely drop it.
 
-Signed-off-by: RafaÅ MiÅecki <zajec5@gmail.com>
+Signed-off-by: Rafał Miłecki <zajec5@gmail.com>
 Signed-off-by: Kalle Valo <kvalo@codeaurora.org>
 ---
 

--- a/package/kernel/mac80211/patches/351-0018-brcmfmac-include-required-headers-in-cfg80211.h.patch
+++ b/package/kernel/mac80211/patches/351-0018-brcmfmac-include-required-headers-in-cfg80211.h.patch
@@ -10,16 +10,16 @@ Without this including cfg80211.h in a wrong order could result in:
 drivers/net/wireless/broadcom/brcm80211/brcmfmac/cfg80211.h:122:24: error: array type has incomplete element type
   struct brcmf_wsec_key key[BRCMF_MAX_DEFAULT_KEYS];
                         ^
-drivers/net/wireless/broadcom/brcm80211/brcmfmac/cfg80211.h:291:24: error: field âp2pâ has incomplete type
+drivers/net/wireless/broadcom/brcm80211/brcmfmac/cfg80211.h:291:24: error: field ‘p2p’ has incomplete type
   struct brcmf_p2p_info p2p;
                         ^
-drivers/net/wireless/broadcom/brcm80211/brcmfmac/cfg80211.h:297:27: error: field âpmk_listâ has incomplete type
+drivers/net/wireless/broadcom/brcm80211/brcmfmac/cfg80211.h:297:27: error: field ‘pmk_list’ has incomplete type
   struct brcmf_pmk_list_le pmk_list;
                            ^
-drivers/net/wireless/broadcom/brcm80211/brcmfmac/cfg80211.h:317:28: error: field âassoclistâ has incomplete type
+drivers/net/wireless/broadcom/brcm80211/brcmfmac/cfg80211.h:317:28: error: field ‘assoclist’ has incomplete type
   struct brcmf_assoclist_le assoclist;
 
-Signed-off-by: RafaÅ MiÅecki <zajec5@gmail.com>
+Signed-off-by: Rafał Miłecki <zajec5@gmail.com>
 Signed-off-by: Kalle Valo <kvalo@codeaurora.org>
 ---
 

--- a/package/kernel/mac80211/patches/351-0019-brcmfmac-slightly-simplify-building-interface-combin.patch
+++ b/package/kernel/mac80211/patches/351-0019-brcmfmac-slightly-simplify-building-interface-combin.patch
@@ -16,7 +16,7 @@ make it simpler:
    before preparing limits).
 3) It modifies mbss code to use i variable just like other combos do.
 
-Signed-off-by: RafaÅ MiÅecki <zajec5@gmail.com>
+Signed-off-by: Rafał Miłecki <zajec5@gmail.com>
 Acked-by: Arend van Spriel <arend.vanspriel@broadcom.com>
 Signed-off-by: Kalle Valo <kvalo@codeaurora.org>
 ---

--- a/package/kernel/mac80211/patches/351-0020-brcmfmac-fix-lockup-when-removing-P2P-interface-afte.patch
+++ b/package/kernel/mac80211/patches/351-0020-brcmfmac-fix-lockup-when-removing-P2P-interface-afte.patch
@@ -18,7 +18,7 @@ assumes rtnl to be unlocked.
 Fix it by adding an extra rtnl_locked parameter to functions and calling
 unregister_netdevice when needed.
 
-Signed-off-by: RafaÅ MiÅecki <zajec5@gmail.com>
+Signed-off-by: Rafał Miłecki <zajec5@gmail.com>
 Signed-off-by: Kalle Valo <kvalo@codeaurora.org>
 ---
  .../wireless/broadcom/brcm80211/brcmfmac/core.c    | 29 +++++++++++++---------

--- a/package/kernel/mac80211/patches/351-0021-brcmfmac-use-const-char-for-interface-name-in-brcmf_.patch
+++ b/package/kernel/mac80211/patches/351-0021-brcmfmac-use-const-char-for-interface-name-in-brcmf_.patch
@@ -11,7 +11,7 @@ more flexible as some cfg80211 callback may provide const char * as
 well, e.g. add_virtual_intf. This will be needed for more advanced
 interface management.
 
-Signed-off-by: RafaÅ MiÅecki <zajec5@gmail.com>
+Signed-off-by: Rafał Miłecki <zajec5@gmail.com>
 Signed-off-by: Kalle Valo <kvalo@codeaurora.org>
 ---
 

--- a/package/kernel/mac80211/patches/351-0022-brcmfmac-include-also-core.h-header-in-cfg80211.h.patch
+++ b/package/kernel/mac80211/patches/351-0022-brcmfmac-include-also-core.h-header-in-cfg80211.h.patch
@@ -8,16 +8,16 @@ Content-Transfer-Encoding: 8bit
 This header provides two inline functions using struct brcmf_if so we
 need core.h to avoid:
 
-drivers/net/wireless/broadcom/brcm80211/brcmfmac/cfg80211.h: In function ândev_to_profâ:
+drivers/net/wireless/broadcom/brcm80211/brcmfmac/cfg80211.h: In function ‘ndev_to_prof’:
 drivers/net/wireless/broadcom/brcm80211/brcmfmac/cfg80211.h:368:13: error: dereferencing pointer to incomplete type
   return &ifp->vif->profile;
              ^
-drivers/net/wireless/broadcom/brcm80211/brcmfmac/cfg80211.h: In function ândev_to_vifâ:
+drivers/net/wireless/broadcom/brcm80211/brcmfmac/cfg80211.h: In function ‘ndev_to_vif’:
 drivers/net/wireless/broadcom/brcm80211/brcmfmac/cfg80211.h:374:12: error: dereferencing pointer to incomplete type
   return ifp->vif;
             ^
 
-Signed-off-by: RafaÅ MiÅecki <zajec5@gmail.com>
+Signed-off-by: Rafał Miłecki <zajec5@gmail.com>
 Signed-off-by: Kalle Valo <kvalo@codeaurora.org>
 ---
 

--- a/package/kernel/mac80211/patches/351-0023-brcmfmac-add-missing-break-when-deleting-P2P_DEVICE.patch
+++ b/package/kernel/mac80211/patches/351-0023-brcmfmac-add-missing-break-when-deleting-P2P_DEVICE.patch
@@ -10,7 +10,7 @@ We obviously don't want to fall through in that switch. With this change
 2) We remove interface manually on timeout
 3) We return 0 on success instead of -ENOTSUPP
 
-Signed-off-by: RafaÅ MiÅecki <zajec5@gmail.com>
+Signed-off-by: Rafał Miłecki <zajec5@gmail.com>
 Signed-off-by: Kalle Valo <kvalo@codeaurora.org>
 ---
 

--- a/package/kernel/mac80211/patches/351-0024-brcmfmac-delete-interface-directly-in-code-that-sent.patch
+++ b/package/kernel/mac80211/patches/351-0024-brcmfmac-delete-interface-directly-in-code-that-sent.patch
@@ -31,7 +31,7 @@ callback, right after receiving confirmation event from firmware. This
 only required modifying worker to don't unregister on its own if there
 is someone waiting for the event.
 
-Signed-off-by: RafaÅ MiÅecki <zajec5@gmail.com>
+Signed-off-by: Rafał Miłecki <zajec5@gmail.com>
 Signed-off-by: Kalle Valo <kvalo@codeaurora.org>
 ---
 

--- a/package/kernel/mac80211/patches/351-0025-brcmfmac-support-removing-AP-interfaces-with-interfa.patch
+++ b/package/kernel/mac80211/patches/351-0025-brcmfmac-support-removing-AP-interfaces-with-interfa.patch
@@ -12,7 +12,7 @@ case of older firmwares (e.g. 7.35.177.56 for BCM43602 as I tested) this
 will just result in firmware rejecting command and this won't change any
 behavior.
 
-Signed-off-by: RafaÅ MiÅecki <zajec5@gmail.com>
+Signed-off-by: Rafał Miłecki <zajec5@gmail.com>
 Signed-off-by: Kalle Valo <kvalo@codeaurora.org>
 ---
 

--- a/package/kernel/mac80211/patches/351-0026-brcmfmac-respect-hidden_ssid-for-AP-interfaces.patch
+++ b/package/kernel/mac80211/patches/351-0026-brcmfmac-respect-hidden_ssid-for-AP-interfaces.patch
@@ -8,7 +8,7 @@ Content-Transfer-Encoding: 8bit
 This was succesfully tested with 4366B1. A small workaround is needed
 for the main interface otherwise it would stuck at the hidden state.
 
-Signed-off-by: RafaÅ MiÅecki <zajec5@gmail.com>
+Signed-off-by: Rafał Miłecki <zajec5@gmail.com>
 Signed-off-by: Kalle Valo <kvalo@codeaurora.org>
 ---
 

--- a/package/kernel/mac80211/patches/351-0027-brcmfmac-restore-stopping-netdev-queue-when-bus-clog.patch
+++ b/package/kernel/mac80211/patches/351-0027-brcmfmac-restore-stopping-netdev-queue-when-bus-clog.patch
@@ -13,7 +13,7 @@ the behaviour is restored.
 
 Cc: stable@vger.kernel.org # v4.5, v4.6, v4.7
 Fixes: 9cd18359d31e ("brcmfmac: Make FWS queueing configurable.")
-Tested-by: Per FÃ¶rlin <per.forlin@gmail.com>
+Tested-by: Per Förlin <per.forlin@gmail.com>
 Reviewed-by: Hante Meuleman <hante.meuleman@broadcom.com>
 Reviewed-by: Pieter-Paul Giesberts <pieter-paul.giesberts@broadcom.com>
 Reviewed-by: Franky Lin <franky.lin@broadcom.com>

--- a/package/kernel/mac80211/patches/351-0031-brcmfmac-Check-rtnl_lock-is-locked-when-removing-int.patch
+++ b/package/kernel/mac80211/patches/351-0031-brcmfmac-Check-rtnl_lock-is-locked-when-removing-int.patch
@@ -54,7 +54,7 @@ e.g.
 [ 4495.876924]  [<ffffffff860e2b8f>] ? trace_hardirqs_off_caller+0x1f/0xc0
 
 Signed-off-by: Masami Hiramatsu <mhiramat@kernel.org>
-Acked-by: RafaÅ MiÅecki <rafal@milecki.pl>
+Acked-by: Rafał Miłecki <rafal@milecki.pl>
 Signed-off-by: Kalle Valo <kvalo@codeaurora.org>
 ---
  drivers/net/wireless/broadcom/brcm80211/brcmfmac/core.c | 2 +-

--- a/package/kernel/mac80211/patches/351-0048-brcmfmac-fix-memory-leak-in-brcmf_fill_bss_param.patch
+++ b/package/kernel/mac80211/patches/351-0048-brcmfmac-fix-memory-leak-in-brcmf_fill_bss_param.patch
@@ -9,7 +9,7 @@ Content-Transfer-Encoding: 8bit
 This function is called from get_station callback which means that every
 time user space was getting/dumping station(s) we were leaking 2 KiB.
 
-Signed-off-by: RafaÅ MiÅecki <rafal@milecki.pl>
+Signed-off-by: Rafał Miłecki <rafal@milecki.pl>
 Fixes: 1f0dc59a6de ("brcmfmac: rework .get_station() callback")
 Cc: stable@vger.kernel.org # 4.2+
 Acked-by: Arend van Spriel <arend.vanspriel@broadcom.com>

--- a/package/kernel/mac80211/patches/351-0049-brcmfmac-drop-unused-fields-from-struct-brcmf_pub.patch
+++ b/package/kernel/mac80211/patches/351-0049-brcmfmac-drop-unused-fields-from-struct-brcmf_pub.patch
@@ -9,7 +9,7 @@ Content-Transfer-Encoding: 8bit
 They seem to be there from the first day. We calculate these values but
 never use them.
 
-Signed-off-by: RafaÅ MiÅecki <rafal@milecki.pl>
+Signed-off-by: Rafał Miłecki <rafal@milecki.pl>
 Signed-off-by: Kalle Valo <kvalo@codeaurora.org>
 ---
  drivers/net/wireless/broadcom/brcm80211/brcmfmac/core.c     | 3 ---

--- a/package/kernel/mac80211/patches/351-0050-brcmfmac-replace-WARNING-on-timeout-with-a-simple-er.patch
+++ b/package/kernel/mac80211/patches/351-0050-brcmfmac-replace-WARNING-on-timeout-with-a-simple-er.patch
@@ -17,7 +17,7 @@ firmware problem and incorrect key update. Raising a WARNING however
 wasn't really that necessary, it doesn't point to any driver bug anymore
 and backtrace wasn't much useful.
 
-Signed-off-by: RafaÅ MiÅecki <rafal@milecki.pl>
+Signed-off-by: Rafał Miłecki <rafal@milecki.pl>
 Acked-by: Arend van Spriel <arend.vanspriel@broadcom.com>
 Signed-off-by: Kalle Valo <kvalo@codeaurora.org>
 ---

--- a/package/kernel/mac80211/patches/351-0051-brcmfmac-use-correct-skb-freeing-helper-when-deletin.patch
+++ b/package/kernel/mac80211/patches/351-0051-brcmfmac-use-correct-skb-freeing-helper-when-deletin.patch
@@ -16,7 +16,7 @@ Freeing skbs without a proper check was leading to counter not being
 properly decreased. This was triggering a WARNING every time
 brcmf_netdev_wait_pend8021x was called.
 
-Signed-off-by: RafaÅ MiÅecki <rafal@milecki.pl>
+Signed-off-by: Rafał Miłecki <rafal@milecki.pl>
 Acked-by: Arend van Spriel <arend@broadcom.com>
 Cc: stable@vger.kernel.org # 4.5+
 Signed-off-by: Kalle Valo <kvalo@codeaurora.org>

--- a/package/kernel/mac80211/patches/860-brcmfmac-add-missing-eth_type_trans-call.patch
+++ b/package/kernel/mac80211/patches/860-brcmfmac-add-missing-eth_type_trans-call.patch
@@ -9,7 +9,7 @@ proper skb setup before passing it to the netif. This was triggering
 "NULL pointer dereference".
 
 Fixes: 9c349892ccc9 ("brcmfmac: revise handling events in receive path")
-Signed-off-by: RafaÅ MiÅecki <zajec5@gmail.com>
+Signed-off-by: Rafał Miłecki <zajec5@gmail.com>
 ---
 
 --- a/drivers/net/wireless/broadcom/brcm80211/brcmfmac/msgbuf.c


### PR DESCRIPTION
When poking through my old OpenWRT code when cleaning up in 2025, I noticed there are two published chaoscalmer repositories.

e6fbf31baa git://git.archive.openwrt.org/15.05/openwrt.git:master 
5c2685a7a3 git://git.openwrt.org/openwrt/svn-archive/archive.git:chaos_calmer

The latest commits in git.archive.openwrt.org were in September 2016 and were svn imports.  The svn-archive repo on git.openwrt.org had true git commits on top of the svn imports until the end of 2017. The two branches do not share a common commit for an easy rebase.  Neither branch was strictly superior to the other.

e6fbf31baa older, missing valuable commits
5c2685a7a3 encoding issues

f9755e2877 from the newer repo was identified as being close to the tip of the older one (essentially only missing commit 29fcc94c9a).  This commit here is then basically the result of commit the result of

git checkout e6fbf31baa -b wip.chaoscalmer
git diff f9755e2877 5c2685a7a3 -- package/kernel/ | git apply - git commit